### PR TITLE
Preserve puzzle contents (entities) when changing width and height #22

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -395,6 +395,9 @@ var EditorCtrl = function(
       $scope['neg'] = n == 'negative';
     }
   }
+  $scope.eraseAll = function () {
+    $grid.eraseAll();
+  }
   $scope.getSelectClass = function(n) {
     return n == $scope['obj'] ? 'isSelected' : null;
   }
@@ -1060,6 +1063,9 @@ GridService.prototype.newGridUi_ = function(data) {
   uiHook.showToast = goog.bind(this.mdToast.showSimple, this.mdToast);
   var gui = new windmill.GridUi(grid, uiHook);
   return gui;
+}
+GridService.prototype.eraseAll = function() {
+  this.currentGrid().eraseAll();
 }
 // Now, all of the convenient grid access functions.
 // They all throw if there's no grid.

--- a/src/build.tmpl.html
+++ b/src/build.tmpl.html
@@ -19,7 +19,7 @@
           </md-select>
         </md-input-container>
       </div>
-      <p class="md-caption" style="margin: 0">Warning: Changing dimensions will wipe out this puzzle.</p>
+      <p class="md-caption" style="margin: 0">Warning: Changing dimensions will remove any elements that no longer fit.</p>
       <!--<h2 class="md-title">Grid cells</h2>-->
       <hr>
       <div style="margin-left: -10px;">
@@ -82,6 +82,13 @@
                    ng-click="select('basic'); $event.stopPropagation()"
                    ng-class="getSelectClass('basic')">
           <md-icon md-svg-src="basic"></md-icon>
+        </md-button>
+        <md-button class="md-raised"
+                   style="background-color: rgba(0, 0, 0, 0)"
+                   title="Restore all cells, lines, and points to default grid"
+                   aria-label=""
+                   ng-click="eraseAll()">
+            Erase All
         </md-button>
       </div>
       <hr>

--- a/src/grid.js
+++ b/src/grid.js
@@ -306,6 +306,27 @@ Grid.prototype.setSymmetry = function(symmetry) {
   this.symmetry = symmetry;
   this.sanitize();
 }
+Grid.prototype.setSize = function(width, height) {
+  var lastStoreWidth = this.storeWidth;
+  var lastStoreHeight = this.storeHeight;
+  var lastEntities = this.entities;
+
+  this.width = width;
+  this.height = height;
+  this.storeWidth = this.width*2 + 1;
+  this.storeHeight = this.height*2 + 1;
+  this.entities = [];
+
+  for (var b = 0; b < this.storeHeight; b++) {
+    for (var a = 0; a < this.storeWidth; a++) {
+      if (a < lastStoreWidth && b < lastStoreHeight) {
+        this.entities[a + this.storeWidth*b] = lastEntities[a + lastStoreWidth*b];
+      } else {
+        this.entities[a + this.storeWidth*b] = new Entity();
+      }
+    }
+  }
+}
 Grid.prototype.sanitize = function() {
   var sym = this.getSymmetry();
   if (!sym) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -241,6 +241,9 @@ GridUi.prototype.dispose = function() {
   // object again', but let's be generous/safe.
   this.eventHandler = this.snakeHandler = null;
 }
+GridUi.prototype.eraseAll = function() {
+  this.grid.initialize(this.grid.width, this.grid.height);
+}
 GridUi.prototype.clearEditEntity = function() {
   this.editEntity = null;
   this.render();
@@ -250,7 +253,7 @@ GridUi.prototype.setEditEntity = function(data) {
   // TODO: Should move setting width/height/symmetry to a different method?
   this.editEntity = null;
   if (data.width != this.grid.width || data.height != this.grid.height) {
-    this.grid.initialize(data.width, data.height);
+    this.grid.setSize(data.width, data.height);
   }
   if (data.symmetry != this.grid.symmetry) {
     this.grid.setSymmetry(data.symmetry);


### PR DESCRIPTION
Add a new `setSize` method to Grid that copies over elements from the
old grid.

Now that changing the grid size doesn't clear the puzzle, add an "erase
all button" to do that.  Pipe the erase all method through from the UI
to the grid.
