### PR TITLE
Keep the start and end points in reasonable places when resizing

### DIFF
--- a/src/grid.js
+++ b/src/grid.js
@@ -170,7 +170,7 @@ Grid.prototype.drawTypeEntity = function(coord, drawType, opt_val) {
 Grid.prototype.getHash = function() {
   var isEmpty = function(e) {
     return (!e.type || e.type == Type.BASIC) &&
-        !e.color && !e.shape && !e.orientation;
+        !e.color && !e.shape;
   }
   // Run length encode empty entities.
   // wow. such imperative. much state invariants.
@@ -232,9 +232,10 @@ Grid.prototype.getEntityRepr = function(
     content.drawType = this.getDrawType(opt_a, opt_b);
   }
   var extras = {};
-  if (value.orientation && type == Type.END) {
-    extras.horizontal = value.orientation.horizontal;
-    extras.vertical = value.orientation.vertical;
+  if (type == Type.END && coordsDefined) {
+    var orientation = this.getEndPlacement(content.i, content.j);
+    extras.horizontal = orientation.horizontal;
+    extras.vertical = orientation.vertical;
     if (Math.abs(extras.horizontal) + Math.abs(extras.vertical) != 1) {
       // Should we try to infer one?
       return null;
@@ -353,10 +354,6 @@ Grid.prototype.sanitize = function() {
       if (i == ref.i && j == ref.j) {
         this.pointEntity(i, j, new Entity());
       } else if (value.type != refValue.type) {
-        if (value.type == Type.END) {
-          value = new Entity(value);
-          value.orientation = this.getEndPlacement(ref.i, ref.j);
-        }
         this.pointEntity(ref.i, ref.j, value);
       }
     }

--- a/src/grid.js
+++ b/src/grid.js
@@ -320,6 +320,19 @@ Grid.prototype.setSymmetry = function(symmetry) {
   this.sanitize();
 }
 Grid.prototype.setSize = function(width, height) {
+  // If the start and end are in the normal place, erase them and re-add them
+  // in the new normal places.
+  var hadStartInNormalPlace = false;
+  if (this.pointEntity(0, this.height).type == Type.START) {
+    hadStartInNormalPlace = true;
+    this.pointEntity(0, this.height, new Entity());
+  }
+  var hadEndInNormalPlace = false;
+  if (this.pointEntity(this.width, 0).type == Type.END) {
+    hadEndInNormalPlace = true;
+    this.pointEntity(this.width, 0, new Entity());
+  }
+
   var lastStoreWidth = this.storeWidth;
   var lastStoreHeight = this.storeHeight;
   var lastEntities = this.entities;
@@ -330,14 +343,25 @@ Grid.prototype.setSize = function(width, height) {
   this.storeHeight = this.height*2 + 1;
   this.entities = [];
 
+  var hasStart = false;
+  var hasEnd = false;
   for (var b = 0; b < this.storeHeight; b++) {
     for (var a = 0; a < this.storeWidth; a++) {
       if (a < lastStoreWidth && b < lastStoreHeight) {
-        this.entities[a + this.storeWidth*b] = lastEntities[a + lastStoreWidth*b];
+        var entity = lastEntities[a + lastStoreWidth*b];
+        hasStart = hasStart || (entity.type == Type.START);
+        hasEnd = hasEnd || (entity.type == Type.END);
+        this.entities[a + this.storeWidth*b] = entity;
       } else {
         this.entities[a + this.storeWidth*b] = new Entity();
       }
     }
+  }
+  if (hadStartInNormalPlace || !hasStart) {
+    this.pointEntity(0, this.height, new Entity(Type.START));
+  }
+  if (hadEndInNormalPlace || !hasEnd) {
+    this.pointEntity(this.width, 0, new Entity(Type.END));
   }
   this.sanitize();
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -335,15 +335,7 @@ GridUi.prototype.attemptInsert = function(coord, drawType, el) {
   }, this);
   if (el.getAttribute('data-op') == '1') {
     var insert = goog.bind(function(coord, drawType) {
-      var entity = new Entity(this.editEntity);
-      if (entity.type == Type.END) {
-        var orient = this.grid.getEndPlacement(coord.i, coord.j);
-        if (!orient) {
-          return;
-        }
-        entity.orientation = orient;
-      }
-      this.grid.drawTypeEntity(coord, drawType, entity);
+      this.grid.drawTypeEntity(coord, drawType, new Entity(this.editEntity));
     }, this);
     // Regular insertion
     var other = otherCoord(this.editEntity);
@@ -708,7 +700,7 @@ GridUi.NavigationSelector.prototype.pointIsReachable = function(
   }
   // If point is not there, we can go to the end.
   if (thisEntity.type == Type.END) {
-    var o = thisEntity.orientation;
+    var o = grid.getEndPlacement(current.i, current.j);
     if (o.horizontal == di && o.vertical == dj) {
       return 'end';
     }


### PR DESCRIPTION
Before these changes, the start and end points would be removed if you made the grid smaller, and they'd end up in unexpected places if you made the grid larger.  With these changes, the start and end points move to match the new size.
