### PR TITLE
Change the default grid size to 4x4

### DIFF
--- a/src/grid.js
+++ b/src/grid.js
@@ -22,7 +22,7 @@ windmill.Grid = function() {
   this.num = Grid.num_++;
   // Also need to set default width and height.
   // Do not render just yet.
-  this.initialize(5, 5);
+  this.initialize(4, 4);
 }
 var Grid = windmill.Grid;
 Grid.num_ = 0;


### PR DESCRIPTION
A plurality (9/20) of the top puzzles are 4x4, despite 5x5 being the default.  We should make 4x4 the default instead, since that size clearly tends to produce better puzzles.