### PR TITLE
Free and fixed shapes should be different for the purposes of cancellation.

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -834,7 +834,7 @@ var TetrisValidationAttempt = function(
 }
 var uniqueShapes = function(shapes) {
   var uniqueRemaining = [];
-  goog.array.removeDuplicates(shapes, uniqueRemaining, shapeKey);
+  goog.array.removeDuplicates(shapes, uniqueRemaining, fullShapeKey);
   return {
     uniqueShapes: uniqueRemaining,
     removeFn: function(shape) {


### PR DESCRIPTION
Use `fullShapeKey` instead of `shapeKey` for deduplication.

This fixes the issue discovered in <https://windmill.thefifthmatt.com/tvby3gg>.