### PR TITLE
Make ellipsis tile same size as other tiles

### DIFF
--- a/src/index.tmpl.html
+++ b/src/index.tmpl.html
@@ -45,7 +45,7 @@
     </div>
   </div>
 </div>
-<div class="gridSquare" style="border: none;" ng-show="more">
+<div class="gridSquare" style="border-color: #0000;" ng-show="more">
   <!-- smaller -->
   <a ng-click="loadMore()" class="fill">
     <md-icon class="material-icons gridView">more_horiz</md-icon>


### PR DESCRIPTION
If you look closely, the ellipsis tile isn't centered:

![image](https://user-images.githubusercontent.com/5344234/55626549-1494f600-5769-11e9-93da-af245329eb6d.png)

It turns out that by disabling the 3px borders, the size of the ellipsis tile is dropped from 206x206 to 200x200.

This commit solves this by making the borders invisible instead of disabling them.

Again, this is incredibly trivial, so no worries if this would just muddy pull request history.